### PR TITLE
flake: fix bindgen build issue

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,7 @@
             libxkbcommon
             libglvnd
           ];
+          installCargoArtifactsMode = "use-zstd";
         };
 
         cargoArtifacts = craneLib.buildDepsOnly pkgDef;


### PR DESCRIPTION
This fixes the build issue described in https://github.com/pop-os/xdg-desktop-portal-cosmic/issues/8.

There was a similar issue reported here: https://github.com/ipetkov/crane/issues/411
Adding `installCargoArtifactsMode = "use-zstd";` to `pkgDef` fixes the build issue for `cosmic-nix/xdg-desktop-portal-cosmic`.